### PR TITLE
Comments in wrappers' imlementation fix

### DIFF
--- a/gfootball/examples/run_multiagent_rllib.py
+++ b/gfootball/examples/run_multiagent_rllib.py
@@ -45,7 +45,7 @@ class RllibGFootball(MultiAgentEnv):
         logdir='/tmp/rllib_test',
         enable_goal_videos=False, enable_full_episode_videos=False, render=True,
         dump_frequency=0,
-        number_of_players_agent_controls=num_agents,
+        number_of_left_players_agent_controls=num_agents,
         channel_dimensions=(42, 42))
     self.action_space = gym.spaces.Discrete(self.env.action_space.nvec[1])
     self.observation_space = gym.spaces.Box(


### PR DESCRIPTION
There were a few misleading comments in wrappers implementation:
- Wrong shape of Simple115StateWrapper output,
- Descriptions of SingleAgentObservationWrapper and SingleAgentRewardWrapper were copy-pasted from SMMWrapper.