### PR TITLE
Changed colours for video dumps: right team does not blend with the background

### DIFF
--- a/gfootball/env/observation_processor.py
+++ b/gfootball/env/observation_processor.py
@@ -123,7 +123,7 @@ def get_frame(trace):
         player_coord[0],
         player_coord[1],
         field_coords=True,
-        color=(0, 0, 255))
+        color=(255, 255, 0))
     letter = 'A'
     if 'opponent_active' in trace and player_idx in trace['opponent_active']:
       letter = 'Y'


### PR DESCRIPTION
When performing a video dump, the right team's players, colored with dark blue (#0000FF) are quite indistinguishible from the black background. I think that the change of their coloring to yellow is a good idea.