### PR TITLE
Update pip dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ To quit the game press Ctrl+C in the terminal.
 ### Run training
 In order to run TF training, install additional dependencies:
 
-- Update PIP, so that tensorflow 1.15rc2 is available: `python3 -m pip install --upgrade pip`
-- TensorFlow: `pip3 install "tensorflow==1.15rc2"` or
-  `pip3 install "tensorflow-gpu==1.15rc2"`, depending on whether you want CPU or
+- Update PIP, so that tensorflow 1.15 is available: `python3 -m pip install --upgrade pip`
+- TensorFlow: `pip3 install "tensorflow==1.15"` or
+  `pip3 install "tensorflow-gpu==1.15"`, depending on whether you want CPU or
   GPU version;
-- Sonnet: `pip3 install dm-sonnet`;
+- Sonnet: `pip3 install "dm-sonnet<2.0.0"`;
 - OpenAI Baselines:
   `pip3 install git+https://github.com/openai/baselines.git@master`.
 


### PR DESCRIPTION
Recently dm-sonnet was updated to version 2.0.0 and it only supports Tensor Flow 2. 
When I run 
`python3 -m gfootball.play_game --players "ppo2_cnn:left_players=1,policy=gfootball_impala_cnn,checkpoint=$my_checkpoint"`
I get the following error: 
`AssertionError: Sonnet v2 requires TensorFlow 2`
Installing the previous version of sonnet (currently 1.36) fixes the issue.