### PR TITLE
check for and handle numpy ints in remote step()

### DIFF
--- a/gfootball/env/remote_football_env.py
+++ b/gfootball/env/remote_football_env.py
@@ -27,6 +27,7 @@ from gfootball.eval_server.proto import master_pb2
 from gfootball.eval_server.proto import master_pb2_grpc
 import grpc
 import gym
+import numpy as np
 
 
 CONNECTION_TRIALS = 20
@@ -90,6 +91,8 @@ class RemoteFootballEnv(gym.Env):
   def step(self, action):
     if self._game_id is None:
       raise RuntimeError('Environment should be reset!')
+    if np.isscalar(action):
+      action = int(action)
     if isinstance(action, int):
       action = [action]
     request = game_server_pb2.StepRequest(

--- a/gfootball/env/remote_football_env.py
+++ b/gfootball/env/remote_football_env.py
@@ -92,9 +92,7 @@ class RemoteFootballEnv(gym.Env):
     if self._game_id is None:
       raise RuntimeError('Environment should be reset!')
     if np.isscalar(action):
-      action = int(action)
-    if isinstance(action, int):
-      action = [action]
+      action = [int(action)]
     request = game_server_pb2.StepRequest(
         game_version=config.game_version, game_id=self._game_id,
         username=self._username, token=self._token, action=-1,


### PR DESCRIPTION
The remote env threw an error when passing a numpy int64 as the action in step() due to the int not being wrapped as a list. This PR makes sure that the action is an int so that it can be wrapped in a list.