### PR TITLE
Fix pip dependencies in Dockerfile and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -yq git cmake build-essential \
   libdirectfb-dev libst-dev mesa-utils xvfb x11vnc \
   libsdl-sge-dev python3-pip
 
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install tensorflow==1.15rc2 dm-sonnet psutil
+RUN python3 -m pip install --upgrade pip setuptools
+RUN pip3 install tensorflow==1.15.* dm-sonnet==1.* psutil
 
 RUN pip3 install git+https://github.com/openai/baselines.git@master
 COPY . /gfootball

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ To quit the game press Ctrl+C in the terminal.
 ### Run training
 In order to run TF training, install additional dependencies:
 
-- Update PIP, so that tensorflow 1.15 is available: `python3 -m pip install --upgrade pip`
-- TensorFlow: `pip3 install "tensorflow==1.15"` or
-  `pip3 install "tensorflow-gpu==1.15"`, depending on whether you want CPU or
+- Update PIP, so that tensorflow 1.15 is available: `python3 -m pip install --upgrade pip setuptools`
+- TensorFlow: `pip3 install tensorflow==1.15.*` or
+  `pip3 install tensorflow-gpu==1.15.*`, depending on whether you want CPU or
   GPU version;
-- Sonnet: `pip3 install "dm-sonnet<2.0.0"`;
+- Sonnet: `pip3 install dm-sonnet==1.*`;
 - OpenAI Baselines:
   `pip3 install git+https://github.com/openai/baselines.git@master`.
 

--- a/gfootball/doc/docker.md
+++ b/gfootball/doc/docker.md
@@ -11,7 +11,7 @@ cd football
 1. Enter the image with `docker run -e DISPLAY=$DISPLAY -it -v /tmp/.X11-unix:/tmp/.X11-unix:rw gfootball bash`
 
 ## GPU version
-1. Build with `docker build --build-arg DOCKER_BASE=tensorflow/tensorflow:1.14.0-gpu-py3 --build-arg DEVICE=gpu . -t gfootball`
+1. Build with `docker build --build-arg DOCKER_BASE=tensorflow/tensorflow:1.15.2-gpu-py3 --build-arg DEVICE=gpu . -t gfootball`
 1. Enter the image with `nvidia-docker run -e DISPLAY=$DISPLAY -it -v /tmp/.X11-unix:/tmp/.X11-unix:rw gfootball bash` or `docker run --gpus all -e DISPLAY=$DISPLAY -it -v /tmp/.X11-unix:/tmp/.X11-unix:rw gfootball bash` for docker 19.03 or later.
 
 Inside the Docker image you can interact with the environment the same way as in case of local installation.


### PR DESCRIPTION
As explained in #134 Sonnet v2 requires TensorFlow 2, so it should be fixed in the docker file too. 
I also updated DOCKER-BASE to the latest available image: tensorflow:1.15.2-gpu-py3. 

Note: I haven't got rendering working with docker yet. I have Ubuntu 18.04 and Titan Xp GPU and get 
`ALSA lib confmisc.c:767:(parse_card) cannot find card '0'` 
and 
`error: XDG_RUNTIME_DIR not set in the environment.`
`Couldn't load GL function glBegin: Video subsystem has not been initialized` 
among others. 
I installed `nvidia-container-toolkit` following instructions from [here](https://github.com/NVIDIA/nvidia-docker#ubuntu-160418042004-debian-jessiestretchbuster) and 
`docker run --gpus all nvidia/cuda:10.0-base nvidia-smi`
works fine and outputs the name of my GPU. It might be a problem with my installation, so I'll investigate further when I have free time. 
