### PR TITLE
Support Docker on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Bash scripts should always have LF line endings to support Docker on Windows
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ third_party/gfootball_engine/CMakeFiles/
 third_party/gfootball_engine/Makefile
 third_party/gfootball_engine/cmake_install.cmake
 third_party/gfootball_engine/gameplayfootball
-footballenv/
+football-env/
 cmake-build-debug/
+.idea
+.vs


### PR DESCRIPTION
When running `docker build` on Windows there is an error 
` sh: 1: gfootball/build_game_engine.sh: not found`
which is caused by line endings. [This blog post](https://techblog.dorogin.com/case-of-windows-line-ending-in-bash-script-7236f056abe) explains the issue and the solution.

The other approach might be to install `doc2unix` inside the container and run it to convert bash scripts as shown [here](https://willi.am/blog/2016/08/11/docker-for-windows-dealing-with-windows-line-endings/). But adding `.gitattributes` file looks much easier and it won't change anything on Unix systems. 