### PR TITLE
Update instructions for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ First install [brew](https://brew.sh/). It should automatically install Command 
 Next install required packages:
 
 ```
-brew install git python3 cmake sdl2 sdl2_image sdl2_ttf sdl2_gfx boost
+brew install git python3 cmake sdl2 sdl2_image sdl2_ttf sdl2_gfx boost boost-python3
 ```
-and boost-python3, that supports Python 3.7:
+To set up `pygame`, it is also required to install older versions of SDL:
 
 ```
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/527d96f84d4632d30b281ef5b26717e0a75edcb4/Formula/boost-python3.rb
+brew install sdl sdl_image sdl_mixer sdl_ttf portmidi
 ```
 
 #### 2a. From PyPi package


### PR DESCRIPTION
Updated instructions for MacOS (see comments [here](https://github.com/google-research/football/issues/128#issuecomment-663062611) and [here](https://github.com/google-research/football/issues/156#issuecomment-663543398)). Brew installs Python 3.8 now, and it seems that everything works fine, and there is no need to install `boost-python37` anymore. 