### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -yq git cmake build-essential \
   libsdl-sge-dev python3-pip
 
 RUN python3 -m pip install --upgrade pip setuptools
-RUN pip3 install tensorflow==1.15.* dm-sonnet==1.* psutil
+RUN pip3 install --no-cache-dir tensorflow==1.15.* dm-sonnet==1.* psutil
 
-RUN pip3 install git+https://github.com/openai/baselines.git@master
+RUN pip3 install --no-cache-dir git+https://github.com/openai/baselines.git@master
 COPY . /gfootball
 RUN cd /gfootball && pip3 install .
 WORKDIR '/gfootball'


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>