### PR TITLE
Fix GitHub Actions workflow run

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -3,10 +3,13 @@ name: Build and Publish Python Wheels
 on:
   release:
     types: [published]
+  # Allow to trigger the workflow manually
+  workflow_dispatch:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    # TODO: Change back to windows-latest once the SDK problem is resolved
+    runs-on: windows-2016
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +65,7 @@ jobs:
       working-directory: football
 
     - name: Install the package using the wheel
-      run: python -m pip install temp-gfootball --no-index --find-links=dist
+      run: python -m pip install gfootball --no-index --find-links=dist
       working-directory: football
 
     - name: Run the tests

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: microsoft/vcpkg
-        ref: 025e564979cc01d0fbc5c920aa8a36635efb01bb
+        ref: 47d2378c8181ece05ffc51acd2ed60d97e3c9a64
         path: vcpkg
         fetch-depth: 0
 

--- a/gfootball/env/football_env_test.py
+++ b/gfootball/env/football_env_test.py
@@ -25,6 +25,7 @@ from multiprocessing import Queue
 import gfootball
 import os
 import platform
+import sys
 import random
 import threading
 import atexit
@@ -151,7 +152,7 @@ class FootballEnvTest(parameterized.TestCase):
           # Linux
           expected_hash_value = 1374617688
           if platform.system() == 'Windows':
-            expected_hash_value = 1828377453
+            expected_hash_value = 1340093059 if sys.maxsize > 2**32 else 1852024489
           elif platform.system() == 'Darwin':
             expected_hash_value = 2070005886
           self.assertEqual(hash_value, expected_hash_value)
@@ -160,7 +161,7 @@ class FootballEnvTest(parameterized.TestCase):
           # Linux
           expected_hash_value = 2457763948
           if platform.system() == 'Windows':
-            expected_hash_value = 2766829577
+            expected_hash_value = 3460273443 if sys.maxsize > 2**32 else 369415907
           elif platform.system() == 'Darwin':
             expected_hash_value = 876758366
           self.assertEqual(hash_value, expected_hash_value)
@@ -169,7 +170,7 @@ class FootballEnvTest(parameterized.TestCase):
           # Linux
           expected_hash_value = 867340920
           if platform.system() == 'Windows':
-            expected_hash_value = 2630021865
+            expected_hash_value = 1404099525 if sys.maxsize > 2**32 else 3687472990
           elif platform.system() == 'Darwin':
             expected_hash_value = 991389279
           self.assertEqual(hash_value, expected_hash_value)
@@ -309,7 +310,7 @@ class FootballEnvTest(parameterized.TestCase):
     # Linux
     expected_hash_value = 3642886809
     if platform.system() == 'Windows':
-      expected_hash_value = 683941870
+      expected_hash_value = 3676773624 if sys.maxsize > 2**32 else 2808421794
     elif platform.system() == 'Darwin':
       expected_hash_value = 1865563121
     self.assertEqual(hash_value, expected_hash_value)

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.6/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.6/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
   "version-string": "2.10",
-  "builtin-baseline": "025e564979cc01d0fbc5c920aa8a36635efb01bb",
+  "builtin-baseline": "47d2378c8181ece05ffc51acd2ed60d97e3c9a64",
   "dependencies": [
     "python3",
     "boost-thread",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.7/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.7/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
   "version-string": "2.10",
-  "builtin-baseline": "025e564979cc01d0fbc5c920aa8a36635efb01bb",
+  "builtin-baseline": "47d2378c8181ece05ffc51acd2ed60d97e3c9a64",
   "dependencies": [
     "python3",
     "boost-thread",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.8/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.8/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
   "version-string": "2.10",
-  "builtin-baseline": "025e564979cc01d0fbc5c920aa8a36635efb01bb",
+  "builtin-baseline": "47d2378c8181ece05ffc51acd2ed60d97e3c9a64",
   "dependencies": [
     "python3",
     "boost-thread",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.9/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.9/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
   "version-string": "2.10",
-  "builtin-baseline": "025e564979cc01d0fbc5c920aa8a36635efb01bb",
+  "builtin-baseline": "47d2378c8181ece05ffc51acd2ed60d97e3c9a64",
   "dependencies": [
     "python3",
     "boost-thread",
@@ -17,6 +17,6 @@
     "opengl"
   ],
   "overrides": [
-    { "name": "python3", "version-string": "3.9.6" }
+    { "name": "python3", "version-string": "3.9.7" }
   ]
 }


### PR DESCRIPTION
Windows 11 Preview SDK (10.0.22000.0) [was recently added](https://github.com/actions/virtual-environments/pull/4014) to the [GitHub's virtual environment](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md) and it's causing problems with Python builds. There is [an issue](https://bugs.python.org/issue45220) on Python's bug tracker posted last week, that states that this bug prevented CI for Python builds. There is [an open issue](https://github.com/microsoft/vcpkg/issues/17211) in the `vcpkg` repo, and a [corresponding PR](https://github.com/microsoft/vcpkg/pull/20292). But it will only fix Python 3.9.7 builds and not the previous versions. See the [comment](https://github.com/google-research/football/pull/277#issuecomment-925904067) for the details.

Until a proper fix is ready we should run the build on `windows-2016` instead of `windows-latest`, which has Visual Studio 2017 installed.

@qstanczyk
Piotr, once you merge the PR, you can navigate [to the workflow](https://github.com/google-research/football/actions/workflows/publish-wheels.yml) and manually start the build by clicking `Run workflow`.