### PR TITLE
Update deprecated FindPythonLibs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ python -m pip install --upgrade pip setuptools psutil wheel
 
 
 #### 2. Install GFootball
-#### 2a. From PyPi package
+#### Option a. From PyPi package (recommended)
 ```shell
 python3 -m pip install gfootball
 ```
 
-#### 2b. Installing from sources using GitHub repository
+#### Option b. Installing from sources using GitHub repository 
+(On Windows you have to install additional tools and set environment variables, see 
+[Compiling Engine](gfootball/doc/compile_engine.md#windows) for detailed instructions.)
 
 ```shell
 git clone https://github.com/google-research/football.git
@@ -85,9 +87,8 @@ Next, build the game engine and install dependencies:
 python3 -m pip install .
 ```
 This command can run for a couple of minutes, as it compiles the C++ environment in the background.
+If you face any problems, first check [Compiling Engine](gfootball/doc/compile_engine.md) documentation and search GitHub issues.
 
-To compile the engine on Windows you have to install additional tools and set environment variables. See 
-[Compiling Engine](gfootball/doc/compile_engine.md#windows) for detailed instructions.
 
 #### 3. Time to play!
 ```shell

--- a/gfootball/doc/compile_engine.md
+++ b/gfootball/doc/compile_engine.md
@@ -25,11 +25,8 @@ Finally, install [vcpkg](https://github.com/microsoft/vcpkg) by following a
 cd C:\dev
 :: Clone vckpg
 git clone https://github.com/microsoft/vcpkg.git
-cd vckpg
 :: Run installation script
-.\bootstrap-vcpkg.bat
-:: Return to previous directory
-cd ..
+.\vcpkg\bootstrap-vcpkg.bat
 ```
 
 If you have `vcpkg` already installed, consider updating it to the latest commit and running `.\bootstrap-vcpkg.bat`.
@@ -55,7 +52,7 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install psutil
 
 :: Run the installation. It installs vcpkg dependencies and compiles the engine
-pip install . --use-feature=in-tree-build
+pip install .
 ```
 
 
@@ -96,7 +93,7 @@ python3 -m pip install psutil
 Finally, build the game environment:
 
 ```shell
-python3 -m pip install . --use-feature=in-tree-build
+python3 -m pip install .
 ```
 
 #### Installation with conda
@@ -112,7 +109,7 @@ conda deactivate
 $(brew --prefix python3)/bin/python3.9 -m venv football-env
 source football-env/bin/activate
 python3 -m pip install --upgrade pip setuptools psutil wheel
-python3 -m pip install . --use-feature=in-tree-build
+python3 -m pip install .
 ```
 
 ### Apple Silicon
@@ -148,7 +145,7 @@ python3 -m pip install psutil
 Finally, build the game environment:
 
 ```shell
-python3 -m pip install . --use-feature=in-tree-build
+python3 -m pip install .
 ```
 
 ## Development mode
@@ -158,7 +155,7 @@ in the [development](https://packaging.python.org/guides/distributing-packages-u
 (aka editable) mode by running:
 
 ```shell
-python3 -m pip install -e . --use-feature=in-tree-build
+python3 -m pip install -e .
 ```
 
 In such case, Python source files in projects can be edited in-place without reinstallation,

--- a/gfootball/doc/compile_engine.md
+++ b/gfootball/doc/compile_engine.md
@@ -56,7 +56,7 @@ pip install .
 ```
 
 
-## macOS
+## macOS (both Intel processors and Apple Silicon)
 
 First, install [brew](https://brew.sh/). It should automatically download Command Line Tools.
 Next, install the required packages:
@@ -72,11 +72,9 @@ git clone https://github.com/google-research/football.git
 cd football
 ```
 
-### Intel processor
-#### Installation with brew version of Python
+### Installation with brew version of Python
 It is recommended to use Python shipped with `brew`, because `boost-python3` is compiled against the same version.
 To check which Python 3 is used by default on your setup, execute `which python3`.
-For Intel-based Macs it should be `/usr/local/bin/python3`.
 If you have a different path, and you don't want to change symlinks, create a virtual environment with
 `/usr/local/bin/python3 -m venv football-env` or `$(brew --prefix python3)/bin/python3.9 -m venv football-env`.
 
@@ -96,7 +94,7 @@ Finally, build the game environment:
 python3 -m pip install .
 ```
 
-#### Installation with conda
+### Installation with conda
 
 If you installed the engine using `conda`, you might encounter the following error:
 `TypeError: __init__() should return None, not 'NoneType'` when trying to run the game.
@@ -112,14 +110,6 @@ python3 -m pip install --upgrade pip setuptools psutil wheel
 python3 -m pip install .
 ```
 
-### Apple Silicon
-The environment can be compiled and run on Apple Silicon. Until some dependencies (`opencv-python`, `numpy`, etc.)
-fully support new architecture, the required components should be installed manually beforehand,
-and Google Research Football should be installed without dependencies (`--no-deps`).
-
-#### Installation with conda
-Python dependencies can be installed via `conda's` fork [miniforge](https://github.com/conda-forge/miniforge).
-But you may encounter a `TypeError` when running the game if you use `boost-python3` from `brew`.
 
 ## Linux
 Install required packages:

--- a/third_party/gfootball_engine/CMakeLists.txt
+++ b/third_party/gfootball_engine/CMakeLists.txt
@@ -62,13 +62,14 @@ include_directories(${SDL2_TTF_DIRS})
 include_directories(${SDL2_GFX_DIRS})
 
 if(UNIX)
-  find_package(PythonLibs 3 REQUIRED)
+  find_package(Python COMPONENTS Development REQUIRED)
 else()
   set(PYTHONLIBS_VERSION_STRING $ENV{PY_VERSION})
 endif()
 
-message("Using Python: ${PYTHONLIBS_VERSION_STRING}")
-string(REPLACE "." ";" VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
+message("Using Python: ${Python_VERSION}")
+# TODO: Use Python_VERSION_MAJOR and MINOR provided by FindPython3 package
+string(REPLACE "." ";" VERSION_LIST ${Python_VERSION})
 list(GET VERSION_LIST 0 PYTHON_MAJOR)
 list(GET VERSION_LIST 1 PYTHON_MINOR)
 
@@ -78,8 +79,8 @@ if(WIN32)
   # It was improved only recently (Jan 2021), so we can't use it for earlier py versions:
   # (see https://github.com/microsoft/vcpkg/pull/15221 )
   # To avoid version mismatch we point to vcpkg's libs directly
-  set(PYTHON_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${PYTHON_MAJOR}${PYTHON_MINOR}.lib")
-  set(PYTHON_INCLUDE_DIR "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/include/python${PYTHON_MAJOR}.${PYTHON_MINOR}")
+  set(Python_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${PYTHON_MAJOR}${PYTHON_MINOR}.lib")
+  set(Python_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/include/python${PYTHON_MAJOR}.${PYTHON_MINOR}")
 endif()
 
 # Include Boost Python.
@@ -108,7 +109,8 @@ message("Using python_boost: ${BOOST_PYTHON_VERSION}")
 FIND_PACKAGE(Boost REQUIRED COMPONENTS thread system filesystem ${BOOST_PYTHON_VERSION})
 include_directories(${Boost_INCLUDE_DIR})
 
-include_directories(${PYTHON_INCLUDE_DIR})
+# TODO: Find what is correct: DIR or DIRS (see boost above)
+include_directories(${Python_INCLUDE_DIRS})
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/cmake)
@@ -151,7 +153,7 @@ endif()
 
 set(LIBRARIES gamelib menulib datalib blunted2
    Boost::filesystem Boost::system Boost::thread Boost::${BOOST_PYTHON_VERSION}
-   ${PYTHON_LIBRARIES} ${SDL2_LIBS_ALL} ${EGL_LIBRARIES} ${OPENGL_LIBRARY})
+   ${Python_LIBRARIES} ${SDL2_LIBS_ALL} ${EGL_LIBRARIES} ${OPENGL_LIBRARY})
 
 if(UNIX)
   set(LIB_NAME game)

--- a/third_party/gfootball_engine/CMakeLists.txt
+++ b/third_party/gfootball_engine/CMakeLists.txt
@@ -35,16 +35,15 @@ if(UNIX)
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O3 -g")
 endif(UNIX)
 
-# Find needed libraries
+# Find required libraries
 FIND_PACKAGE(OpenGL REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIRS})
+include_directories(${OPENGL_INCLUDE_DIR})
 
 FIND_PACKAGE(SDL2 REQUIRED)
 include_directories(${SDL2_INCLUDE_DIRS})
 
 if(UNIX AND NOT APPLE)
   FIND_PACKAGE(EGL REQUIRED)
-  # TODO: Change to DIRS according to the convention
   include_directories(${EGL_INCLUDE_DIR})
 endif()
 

--- a/third_party/gfootball_engine/CMakeLists.txt
+++ b/third_party/gfootball_engine/CMakeLists.txt
@@ -11,9 +11,9 @@ if(WIN32)
   endif()
 
   if(${CMAKE_GENERATOR_PLATFORM} STREQUAL Win32)
-    set(VCPKG_TARGET_TRIPLET x86-windows)
+    set(VCPKG_TARGET_TRIPLET "x86-windows")
   elseif(${CMAKE_GENERATOR_PLATFORM} STREQUAL x64)
-    set(VCPKG_TARGET_TRIPLET x64-windows)
+    set(VCPKG_TARGET_TRIPLET "x64-windows")
   else()
     message(FATAL_ERROR "Unsupported Generator Platform, only Win32 or x64 are supported")
   endif()
@@ -40,6 +40,7 @@ FIND_PACKAGE(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 
 FIND_PACKAGE(SDL2 REQUIRED)
+# TODO: Test and change to DIRS
 include_directories(${SDL2_INCLUDE_DIR})
 
 if(UNIX AND NOT APPLE)
@@ -63,35 +64,31 @@ include_directories(${SDL2_GFX_DIRS})
 
 if(UNIX)
   find_package(Python COMPONENTS Development REQUIRED)
-else()
-  set(PYTHONLIBS_VERSION_STRING $ENV{PY_VERSION})
-endif()
-
-message("Using Python: ${Python_VERSION}")
-# TODO: Use Python_VERSION_MAJOR and MINOR provided by FindPython3 package
-string(REPLACE "." ";" VERSION_LIST ${Python_VERSION})
-list(GET VERSION_LIST 0 PYTHON_MAJOR)
-list(GET VERSION_LIST 1 PYTHON_MINOR)
-
-if(WIN32)
+elseif(WIN32)
   # find_package (Python COMPONENTS Development)
   # FindPython package searches for system-wide python installations first.
   # It was improved only recently (Jan 2021), so we can't use it for earlier py versions:
   # (see https://github.com/microsoft/vcpkg/pull/15221 )
   # To avoid version mismatch we point to vcpkg's libs directly
-  set(Python_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${PYTHON_MAJOR}${PYTHON_MINOR}.lib")
-  set(Python_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/include/python${PYTHON_MAJOR}.${PYTHON_MINOR}")
+  set(Python_VERSION $ENV{PY_VERSION})
+  string(REPLACE "." ";" VERSION_LIST Python_VERSION)
+  list(GET VERSION_LIST 0 Python_VERSION_MAJOR)
+  list(GET VERSION_LIST 1 Python_VERSION_MINOR)
+  set(Python_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.lib")
+  set(Python_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/include/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
 endif()
+
+message("Using Python: ${Python_VERSION}")
 
 # Include Boost Python.
 if(WIN32 OR APPLE)
-  set(BOOST_PYTHON_VERSION python${PYTHON_MAJOR}${PYTHON_MINOR})
+  set(BOOST_PYTHON_VERSION python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 else()
   # Unfortunately different linux distributions are using different naming for boost-python
   # list of prefixes: Ubuntu, Debian, Some other distributions
   set(BOOST_PYTHON_PREFIXES python3-py python-py python)
   foreach(BP_PREFIX ${BOOST_PYTHON_PREFIXES})
-    set(BOOST_PYTHON_NAME ${BP_PREFIX}${PYTHON_MAJOR}${PYTHON_MINOR})
+    set(BOOST_PYTHON_NAME ${BP_PREFIX}${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
     string(TOUPPER ${BOOST_PYTHON_NAME} BOOST_PYTHON_NAME_UPPER)
     FIND_PACKAGE(Boost COMPONENTS ${BOOST_PYTHON_NAME})
     if(Boost_${BOOST_PYTHON_NAME_UPPER}_FOUND)
@@ -107,10 +104,12 @@ endif()
 message("Using python_boost: ${BOOST_PYTHON_VERSION}")
 
 FIND_PACKAGE(Boost REQUIRED COMPONENTS thread system filesystem ${BOOST_PYTHON_VERSION})
+# TODO: Test and change to DIRS
 include_directories(${Boost_INCLUDE_DIR})
 
-# TODO: Find what is correct: DIR or DIRS (see boost above)
 include_directories(${Python_INCLUDE_DIRS})
+# Debug:
+message("Python_INCLUDE_DIRS: ${Python_INCLUDE_DIRS}")
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/cmake)

--- a/third_party/gfootball_engine/CMakeLists.txt
+++ b/third_party/gfootball_engine/CMakeLists.txt
@@ -33,6 +33,7 @@ set (CMAKE_CXX_STANDARD 14)
 if(UNIX)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -fPIC -g -O3")
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O3 -g")
+  set(OpenGL_GL_PREFERENCE GLVND)
 endif(UNIX)
 
 # Find required libraries
@@ -62,30 +63,42 @@ include_directories(${SDL2_TTF_DIRS})
 include_directories(${SDL2_GFX_DIRS})
 
 if(UNIX)
-  find_package(Python COMPONENTS Development REQUIRED)
+  if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+    find_package(Python COMPONENTS Development REQUIRED)
+  else()
+    # Starting from CMake 3.12 FindPythonLibs was deprecated in favour of FindPython.
+    # But Ubuntu 18.04 and other older distributions have CMake version less than 3.12,
+    # so we have to support the old behaviour for some time.
+    find_package(PythonLibs 3 REQUIRED)
+    string(REPLACE "." ";" VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
+    list(GET VERSION_LIST 0 Python_VERSION_MAJOR)
+    list(GET VERSION_LIST 1 Python_VERSION_MINOR)
+    set(Python_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+    set(Python_LIBRARIES ${PYTHON_LIBRARIES})
+  endif()
 elseif(WIN32)
   # find_package (Python COMPONENTS Development)
   # FindPython package searches for system-wide python installations first.
   # It was improved only recently (Jan 2021), so we can't use it for earlier py versions:
   # (see https://github.com/microsoft/vcpkg/pull/15221 )
   # To avoid version mismatch we point to vcpkg's libs directly
-  set(Python_VERSION $ENV{PY_VERSION})
-  string(REPLACE "." ";" VERSION_LIST ${Python_VERSION})
+  string(REPLACE "." ";" VERSION_LIST $ENV{PY_VERSION})
   list(GET VERSION_LIST 0 Python_VERSION_MAJOR)
   list(GET VERSION_LIST 1 Python_VERSION_MINOR)
-  set(Python_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.lib")
   set(Python_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/include/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+  set(Python_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.lib")
 endif()
 
-message("Using Python: ${Python_VERSION}")
+message("Using Python: ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+include_directories(${Python_INCLUDE_DIRS})
 
 # Include Boost Python.
 if(WIN32 OR APPLE)
   set(BOOST_PYTHON_VERSION python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 else()
   # Unfortunately different linux distributions are using different naming for boost-python
-  # list of prefixes: Ubuntu, Debian, Some other distributions
-  set(BOOST_PYTHON_PREFIXES python3-py python-py python)
+  # list of prefixes: newer Ubuntu and other distributions, older Ubuntu, Debian
+  set(BOOST_PYTHON_PREFIXES python python3-py python-py)
   foreach(BP_PREFIX ${BOOST_PYTHON_PREFIXES})
     set(BOOST_PYTHON_NAME ${BP_PREFIX}${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
     string(TOUPPER ${BOOST_PYTHON_NAME} BOOST_PYTHON_NAME_UPPER)
@@ -100,12 +113,10 @@ else()
     message(FATAL_ERROR "Boost Python not found")
   endif()
 endif()
-message("Using python_boost: ${BOOST_PYTHON_VERSION}")
+message("Using Boost.Python: ${BOOST_PYTHON_VERSION}")
 
 FIND_PACKAGE(Boost REQUIRED COMPONENTS thread system filesystem ${BOOST_PYTHON_VERSION})
 include_directories(${Boost_INCLUDE_DIRS})
-
-include_directories(${Python_INCLUDE_DIRS})
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/cmake)

--- a/third_party/gfootball_engine/CMakeLists.txt
+++ b/third_party/gfootball_engine/CMakeLists.txt
@@ -37,14 +37,14 @@ endif(UNIX)
 
 # Find needed libraries
 FIND_PACKAGE(OpenGL REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIR})
+include_directories(${OPENGL_INCLUDE_DIRS})
 
 FIND_PACKAGE(SDL2 REQUIRED)
-# TODO: Test and change to DIRS
-include_directories(${SDL2_INCLUDE_DIR})
+include_directories(${SDL2_INCLUDE_DIRS})
 
 if(UNIX AND NOT APPLE)
   FIND_PACKAGE(EGL REQUIRED)
+  # TODO: Change to DIRS according to the convention
   include_directories(${EGL_INCLUDE_DIR})
 endif()
 
@@ -71,7 +71,7 @@ elseif(WIN32)
   # (see https://github.com/microsoft/vcpkg/pull/15221 )
   # To avoid version mismatch we point to vcpkg's libs directly
   set(Python_VERSION $ENV{PY_VERSION})
-  string(REPLACE "." ";" VERSION_LIST Python_VERSION)
+  string(REPLACE "." ";" VERSION_LIST ${Python_VERSION})
   list(GET VERSION_LIST 0 Python_VERSION_MAJOR)
   list(GET VERSION_LIST 1 Python_VERSION_MINOR)
   set(Python_LIBRARIES "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.lib")
@@ -104,12 +104,9 @@ endif()
 message("Using python_boost: ${BOOST_PYTHON_VERSION}")
 
 FIND_PACKAGE(Boost REQUIRED COMPONENTS thread system filesystem ${BOOST_PYTHON_VERSION})
-# TODO: Test and change to DIRS
-include_directories(${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIRS})
 
 include_directories(${Python_INCLUDE_DIRS})
-# Debug:
-message("Python_INCLUDE_DIRS: ${Python_INCLUDE_DIRS}")
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/cmake)
@@ -152,7 +149,7 @@ endif()
 
 set(LIBRARIES gamelib menulib datalib blunted2
    Boost::filesystem Boost::system Boost::thread Boost::${BOOST_PYTHON_VERSION}
-   ${Python_LIBRARIES} ${SDL2_LIBS_ALL} ${EGL_LIBRARIES} ${OPENGL_LIBRARY})
+   ${Python_LIBRARIES} ${SDL2_LIBS_ALL} ${EGL_LIBRARIES} ${OPENGL_LIBRARIES})
 
 if(UNIX)
   set(LIB_NAME game)


### PR DESCRIPTION
This PR fixes build errors on Apple Silicon (as noted in https://github.com/google-research/football/issues/233#issuecomment-1017851333) by using `FindPython` as a default module on Unix systems, while keeping compatibility with older distributions (Ubuntu 18.04, etc.). It also slightly improves handling of Python libraries on Windows.
Starting from CMake 3.12 ([released](https://cmake.org/cmake/help/latest/release/3.12.html) in July 2018) `FindPythonLibs` module [became deprecated](https://cmake.org/cmake/help/latest/module/FindPythonLibs.html) and a new `FindPython` module replaced it. 

Other changes with this PR:
* CMakeLists.txt:
    - Use unified naming style of variables: SDL2_INCLUDE_DIR**S**, Boost_INCLUDE_DIR**S**, OPENGL_LIBRAR**IES**. These are the names that should be used [according to the documentation](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#id5). The singular names, e.g. SDL2_INCLUDE_DIR, are used by the FindPackage modules internally. The only exception is FindOpenGL, which [still returns](https://cmake.org/cmake/help/latest/module/FindOpenGL.html) OPENGL_INCLUDE_DIR.
    -  `OpenGL_GL_PREFERENCE` is set to `GLVND`, to get rid of CMake warning. It may also fix some issues mentioned in #303 on configuring OpenGL without root privileges.
* Documentation:
    - Clarify installation options in the README file.
    - Remove `--use-feature=in-tree-build` from compile_engine.md, since `pip` is finally >= 21.3.
    - Update installation instructions for macOS: there is no more need to install any dependencies manually on Apple Silicon.