### PR TITLE
Update .dockerignore and Dockerfile_examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,39 @@
+.git/
+
+# Output directories
+build*/
 third_party/gfootball_engine/build*/
-build/
-gfootball.egg-info
-football-env*
-.vs
-.idea
+
+# CMake files and directories
+**CMakeCache.txt
+**CMakeFiles/
+**Makefile
+**cmake_install.cmake
+
+# Some Python directories
+gfootball.egg-info/
 dist/
+football-env*/
+# in case someone named virtual environment differently
+**/site-packages/
+**__pycache__/
+
+# Compiled object files and libraries (dynamic and static)
+**/*.o
+**/*.obj
+**/*.so
+**/*.so.*
+**/*.dylib
+**/*.dll
+**/*.a
+**/*.lib
+
+
+# IDEA files
+**.idea/
+**cmake-build-*/
+
+# Visual Studio and VS Code
+**.vsbuild/
+**.vscode/
+**.vs/

--- a/Dockerfile_examples
+++ b/Dockerfile_examples
@@ -10,10 +10,10 @@ RUN apt-get update && apt-get --no-install-recommends install -yq git cmake buil
   python3-pip
 
 RUN python3 -m pip install --upgrade pip setuptools wheel
-RUN pip3 install --no-cache-dir psutil dm-sonnet==1.*
-RUN pip list | grep 'tensorflow ' || pip3 install --no-cache-dir tensorflow==1.15.*
+RUN python3 -m pip install --no-cache-dir psutil dm-sonnet==1.*
+RUN python3 -m pip list | grep 'tensorflow ' || python3 -m pip install --no-cache-dir tensorflow==1.15.*
 
-RUN pip3 install --no-cache-dir git+https://github.com/openai/baselines.git@master
+RUN python3 -m pip install --no-cache-dir git+https://github.com/openai/baselines.git@master
 COPY . /gfootball
-RUN cd /gfootball && pip3 install .
+RUN cd /gfootball && python3 -m pip install .
 WORKDIR '/gfootball'


### PR DESCRIPTION
A new version of `.dockerignore` greatly reduces the number of files (and total size of build context) sent to the Docker daemon. On my machine, it is reduced from 650 Mb to 94 Mb.

In Dockerfile_examples, all calls to `pip` are prepended with `python3 -m`.