### PR TITLE
Support Python 3.10 on Windows

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -13,8 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
         architecture: ['x86', 'x64']
+        # SciPy doesn't provide a wheel for Python 3.10 x86
+        exclude:
+          - python-version: '3.10'
+            architecture: 'x86'
 
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -34,15 +38,15 @@ jobs:
     - name: Upgrade pip and essential dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U build setuptools psutil wheel
-        pip install -r requirements.txt
+        python -m pip install -U build setuptools psutil wheel
+        python -m pip install -r requirements.txt
       working-directory: football
 
     - name: Checkout vcpkg
       uses: actions/checkout@v2
       with:
         repository: microsoft/vcpkg
-        ref: 8e0a801c6253a2c8e81f59427a4a5d66f10c0ca4
+        ref: b18b17865cfb6bd24620a00f30691be6775abb96
         path: vcpkg
         fetch-depth: 0
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,15 @@
 Numbering scheme:
-Each environment release number is of the form vX.Y. X is the major version
-number, Y is the minor version number. Experiment results within the same X
+Each environment release number is of the form vX.Y[.P]. X is the major version
+number, Y is the minor version number, P is the patch version if any. Experiment results within the same X
 should not change, as modifications made to the environment are either
 new features or backward compatible bug fixes. We will maintain vX branches
 pointing at the most recent vX.Y.
+
+v2.10.2
+- Replace deprecated FindPythonLibs CMake module.
+- Support Apple Silicon.
+- Build and publish Python 3.10-x64 wheels on Windows.
+- Speed up `docker build` by ignoring development files.
 
 v2.10.1
 - Improve crash reporting in the engine.

--- a/gfootball/doc/compile_engine.md
+++ b/gfootball/doc/compile_engine.md
@@ -55,7 +55,7 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install psutil
 
 :: Run the installation. It installs vcpkg dependencies and compiles the engine
-pip install . --use-feature=in-tree-build
+python -m pip install .
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ packages = find_packages() + find_packages('third_party')
 
 setup(
     name='gfootball',
-    version='2.10.1',
+    version='2.10.2',
     description=('Google Research Football - RL environment based on '
                  'open-source game Gameplay Football'),
     long_description=('Please see [our GitHub page](https://github.com/google-research/football) '

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.10/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.10/vcpkg.json
@@ -17,6 +17,6 @@
     "opengl"
   ],
   "overrides": [
-    { "name": "python3", "version-string": "3.7.3-3" }
+    { "name": "python3", "version-semver": "3.10.1", "port-version": 4 }
   ]
 }

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.6/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.6/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.1",
-  "builtin-baseline": "8e0a801c6253a2c8e81f59427a4a5d66f10c0ca4",
+  "version-string": "2.10.2",
+  "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",
     "boost-thread",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.8/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.8/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.1",
-  "builtin-baseline": "8e0a801c6253a2c8e81f59427a4a5d66f10c0ca4",
+  "version-string": "2.10.2",
+  "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",
     "boost-thread",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.9/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.9/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.1",
-  "builtin-baseline": "8e0a801c6253a2c8e81f59427a4a5d66f10c0ca4",
+  "version-string": "2.10.2",
+  "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",
     "boost-thread",
@@ -17,6 +17,6 @@
     "opengl"
   ],
   "overrides": [
-    { "name": "python3", "version-string": "3.9.7" }
+    { "name": "python3", "version-semver": "3.9.7", "port-version": 2 }
   ]
 }


### PR DESCRIPTION
The PR adds support of Python 3.10 on Windows. Github Actions are updated to build and publish Python 3.10 (`x64`) wheels (`scipy` doesn't provide Py 3.10 binary wheels for `x86` architecture, and `windows-2016` can't build it from sources). I also updated Changelog with info about other PRs (#307 and #308).

**Note**.  `windows-2016` VM will no longer be available from March 15, 2022, and I will prepare a separate PR to move CI to `windows-2019` or even `windows-2022`.  As [mentioned earlier](https://github.com/google-research/football/pull/277#issuecomment-925904067), `Windows 11`'s SDK broke `Python` builds, and only Py 3.9 and Py 3.10 received patches on `vcpkg`. Most likely, I'll have to fork `vcpkg` repository and manually patch older Python versions. But I hope before that, I'll set up continuous integration and publishing binary wheels for Linux and macOS.