### PR TITLE
Support Conda on macOS; limit gym to 0.21.0; and other changes

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -2,6 +2,8 @@ name: Build gfootball on Mac
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - 'gfootball/doc/**'
       - '*.md'

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,0 +1,32 @@
+name: Build gfootball on Mac
+
+on:
+  push:
+    paths-ignore:
+      - 'gfootball/doc/**'
+      - '*.md'
+      - '.dockerignore'
+      - '.gitignore'
+  workflow_dispatch:
+
+jobs:
+  build-mac:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-10.15, macos-latest ]
+    steps:
+      - name: Check out football repository
+        uses: actions/checkout@v2
+
+      - name: Install brew dependencies
+        run: brew install python3 cmake sdl2 sdl2_image sdl2_ttf sdl2_gfx boost boost-python3
+
+      - name: Upgrade pip and install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel build psutil
+          python3 -m pip install -r requirements.txt
+
+      - name: Build package
+        run: python3 -m build --no-isolation --wheel

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
-    - name: Upgrade pip and essential dependencies
+    - name: Upgrade pip and install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U build setuptools psutil wheel

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -8,13 +8,38 @@ on:
 
 jobs:
   build-windows:
-    # TODO: Change back to windows-latest after March 15, 2022 and exclude unsupported Python versions
-    runs-on: windows-2016
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        os: [windows-latest]
+        python-version: [ '3.9', '3.10' ]
         architecture: ['x86', 'x64']
+        include:
+          - os: windows-2016
+            python-version: '3.6'
+            architecture: 'x86'
+            experimental: true
+          - os: windows-2016
+            python-version: '3.6'
+            architecture: 'x64'
+            experimental: true
+          - os: windows-2016
+            python-version: '3.7'
+            architecture: 'x86'
+            experimental: true
+          - os: windows-2016
+            python-version: '3.7'
+            architecture: 'x64'
+            experimental: true
+          - os: windows-2016
+            python-version: '3.8'
+            architecture: 'x86'
+            experimental: true
+          - os: windows-2016
+            python-version: '3.8'
+            architecture: 'x64'
+            experimental: true
 
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -8,17 +8,13 @@ on:
 
 jobs:
   build-windows:
-    # TODO: Change back to windows-latest once the SDK problem is resolved
+    # TODO: Change back to windows-latest after March 15, 2022 and exclude unsupported Python versions
     runs-on: windows-2016
     strategy:
       fail-fast: false
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
         architecture: ['x86', 'x64']
-        # SciPy doesn't provide a wheel for Python 3.10 x86
-        exclude:
-          - python-version: '3.10'
-            architecture: 'x86'
 
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,29 @@
-third_party/gfootball_engine/build*
+# When updating this file don't forget to update MANIFEST.in
+
+# Python related files
 build/
-*.egg-info
+*.egg-info/
 __pycache__
+dist/
+# virtual environment
+football-env*/
+
+# CMake related directories and files
+third_party/gfootball_engine/build*
+third_party/gfootball_engine/CMakeFiles/
+third_party/gfootball_engine/Testing/
+third_party/gfootball_engine/.cmake/
+cmake-build-*/
+vcpkg_installed/
+C[M,m]akeCache.txt
+Makefile
+cmake_install.cmake
 *.a
 *.so
 *.dylib
-C[M,m]akeCache.txt
-third_party/gfootball_engine/CMakeFiles/
-third_party/gfootball_engine/Makefile
-third_party/gfootball_engine/cmake_install.cmake
-third_party/gfootball_engine/gameplayfootball
-footballenv/
-football-env*/
-cmake-build-debug/
+*.pyd
+*.cbp
+
+# IDE
 .idea
-.vs
-vcpkg_installed/
-dist/
+.vs*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ v2.10.3
 - Improve development setup on all platforms (symlink instead of copying).
 - Fix Boost.Bind compilation warnings.
 - Replace scipy dependency with numpy.
+- Limit Gym version to v0.21.0 for now.
 - Add GitHub workflow for building on macOS.
 
 v2.10.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,11 @@ new features or backward compatible bug fixes. We will maintain vX branches
 pointing at the most recent vX.Y.
 
 v2.10.3
-- Add Conda support on macOS
+- Add Conda support on macOS.
+- Improve development setup on all platforms (symlink instead of copying).
+- Fix Boost.Bind compilation warnings.
+- Replace scipy dependency with numpy.
+- Add GitHub workflow for building on macOS.
 
 v2.10.2
 - Replace deprecated FindPythonLibs CMake module.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ should not change, as modifications made to the environment are either
 new features or backward compatible bug fixes. We will maintain vX branches
 pointing at the most recent vX.Y.
 
+v2.10.3
+- Add Conda support on macOS
+
 v2.10.2
 - Replace deprecated FindPythonLibs CMake module.
 - Support Apple Silicon.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,13 +4,14 @@ recursive-include gfootball/doc *
 recursive-include gfootball/eval_server/proto *
 recursive-include gfootball/examples *
 
-include Dockerfile .dockerignore CHANGELOG CONTRIBUTING.md run_docker_test.sh
+include Dockerfile Dockerfile_examples .dockerignore CHANGELOG CONTRIBUTING.md requirements.txt run_docker_test.sh
 
 recursive-include third_party/fonts *
 recursive-include third_party/gfootball_engine *
-recursive-exclude third_party/gfootball_engine *.a libgame.so cmake_install.cmake Makefile
+recursive-exclude third_party/gfootball_engine *.a *.so cmake_install.cmake Makefile
+
 prune third_party/gfootball_engine/CMakeFiles
-prune third_party/gfootball_engine/cmake-build-debug
+prune third_party/gfootball_engine/cmake-build-*
 prune third_party/gfootball_engine/build*
-prune third_party/gfootball_engine/.vs
+prune third_party/gfootball_engine/.vs*
 prune third_party/gfootball_engine/.idea

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This method doesn't support game rendering on screen - if you want to see the ga
 
 ### Using Docker
 
-This is the recommended way to avoid incompatible package versions.
+This is the recommended way for Linux-based systems to avoid incompatible package versions.
 Instructions are available [here](gfootball/doc/docker.md).
 
 ### On your computer

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python3 -m pip install gfootball
 ```
 
 #### Option b. Installing from sources using GitHub repository 
-(On Windows you have to install additional tools and set environment variables, see 
+(On Windows you have to install additional tools and set an environment variable, see 
 [Compiling Engine](gfootball/doc/compile_engine.md#windows) for detailed instructions.)
 
 ```shell

--- a/gfootball/build_game_engine.sh
+++ b/gfootball/build_game_engine.sh
@@ -21,6 +21,7 @@ if [[ "$OSTYPE" == "darwin"* ]] ; then
 fi
 
 # Take into account # of cores and available RAM for deciding on compilation parallelism.
+# TODO: Try importing psutil and if failed fall back to 1 thread
 PARALLELISM=$(python3 -c 'import psutil; import multiprocessing as mp; print(int(max(1,min((psutil.virtual_memory().available/1000000000-1)/0.5, mp.cpu_count()))))')
 
 # Delete pre-existing version of CMakeCache.txt to make 'python3 -m pip install' work.

--- a/gfootball/doc/compile_engine.md
+++ b/gfootball/doc/compile_engine.md
@@ -58,6 +58,7 @@ python -m pip install .
 
 ## macOS (both Intel processors and Apple Silicon)
 
+### Install prerequisites
 First, install [brew](https://brew.sh/). It should automatically download Command Line Tools.
 Next, install the required packages:
 ```shell
@@ -72,41 +73,33 @@ git clone https://github.com/google-research/football.git
 cd football
 ```
 
-### Installation with brew version of Python
-It is recommended to use Python shipped with `brew`, because `boost-python3` is compiled against the same version.
-To check which Python 3 is used by default on your setup, execute `which python3`.
-If you have a different path, and you don't want to change symlinks, create a virtual environment with
-`/usr/local/bin/python3 -m venv football-env` or `$(brew --prefix python3)/bin/python3.9 -m venv football-env`.
+### Choosing Python distribution
+It is recommended to use Python shipped with `brew` because `boost-python3` is compiled against the same version.
+To check which Python 3 is used by default on your setup, execute `which python3`. If the output is `/usr/local/bin/python3`
+or `/opt/homebrew/bin/python3`, you're good to go.  
+If you see a different path, e.g. `/Library/Frameworks/Python.framework/Versions/3.9/bin/python3` or `...conda...`, 
+create a virtual environment with `$(brew --prefix python3)/bin/python3 -m venv football-env`. If you have `conda`, 
+you might need to deactivate base environment beforehand `conda deactivate`. 
 
+It is possible to use `conda` to create a virtual environment, but make sure that you select the same version of Python 
+that was used to build `boost-python` (`3.9` as of January 2022):
+```shell
+conda create --name football-env python=3.9 -y
+conda activate football-env
+```
+
+### Create virtual environment and build the game
 Use [virtual environment](https://docs.python.org/3/tutorial/venv.html) to avoid messing up with global dependencies:
 
 ```shell
 python3 -m venv football-env
 source football-env/bin/activate
-# update pip and setuptools
-python3 -m pip install --upgrade pip setuptools wheel
-python3 -m pip install psutil
+
 ```
 
 Finally, build the game environment:
 
 ```shell
-python3 -m pip install .
-```
-
-### Installation with conda
-
-If you installed the engine using `conda`, you might encounter the following error:
-`TypeError: __init__() should return None, not 'NoneType'` when trying to run the game.
-It may happen because the `boost-python3` installed with `brew` is compiled against a different
-version of Python (see the [discussion](https://github.com/google-research/football/issues/156)).
-If you successfully installed and ran Google Research Football using `conda` please update this guide.
-For now, the easiest way is to deactivate `conda` environment and install GRF with `brew` version of Python:
-```shell
-conda deactivate
-$(brew --prefix python3)/bin/python3.9 -m venv football-env
-source football-env/bin/activate
-python3 -m pip install --upgrade pip setuptools psutil wheel
 python3 -m pip install .
 ```
 
@@ -148,5 +141,5 @@ in the [development](https://packaging.python.org/guides/distributing-packages-u
 python3 -m pip install -e .
 ```
 
-In such case, Python source files in projects can be edited in-place without reinstallation,
+In such case, Python source files can be edited in-place without reinstallation,
 the changes will be reflected the next time an interpreter process is started.

--- a/gfootball/doc/compile_engine.md
+++ b/gfootball/doc/compile_engine.md
@@ -82,11 +82,7 @@ create a virtual environment with `$(brew --prefix python3)/bin/python3 -m venv 
 you might need to deactivate base environment beforehand `conda deactivate`. 
 
 It is possible to use `conda` to create a virtual environment, but make sure that you select the same version of Python 
-that was used to build `boost-python` (`3.9` as of January 2022):
-```shell
-conda create --name football-env python=3.9 -y
-conda activate football-env
-```
+that was used to build `boost-python3` (`3.9` as of February 2022).
 
 ### Create virtual environment and build the game
 Use [virtual environment](https://docs.python.org/3/tutorial/venv.html) to avoid messing up with global dependencies:
@@ -94,7 +90,18 @@ Use [virtual environment](https://docs.python.org/3/tutorial/venv.html) to avoid
 ```shell
 python3 -m venv football-env
 source football-env/bin/activate
+```
+If you decide to use `conda` environment, use the following commands instead:
 
+```shell
+conda create --name football-env python=3.9 -y
+conda activate football-env
+```
+
+Upgrade `pip`, `setuptools`, `wheel` and install `psutil` inside the virtual environment:
+```shell
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install psutil
 ```
 
 Finally, build the game environment:
@@ -115,6 +122,13 @@ libdirectfb-dev libst-dev mesa-utils xvfb x11vnc python3-pip
 python3 -m pip install --upgrade pip setuptools wheel
 python3 -m pip install psutil
 ```
+
+Clone the repository and navigate to the directory:
+```shell
+git clone https://github.com/google-research/football.git
+cd football
+```
+
 Use [virtual environment](https://docs.python.org/3/tutorial/venv.html) to avoid messing up with global dependencies:
 
 ```shell

--- a/gfootball/doc/docker.md
+++ b/gfootball/doc/docker.md
@@ -6,7 +6,10 @@ git clone https://github.com/google-research/football.git
 cd football
 ```
 
-## Configure Docker
+For **rendering** the game on macOS and Windows, we recommend installing the game according to
+the instructions for your platform in [README](https://github.com/google-research/football#on-your-computer).
+
+## Configure Docker for Rendering (Linux only)
 In order to see rendered game you need to allow Docker containers access X server:
 
 ```
@@ -38,7 +41,7 @@ docker run --gpus all -e DISPLAY=$DISPLAY -it -v /tmp/.X11-unix:/tmp/.X11-unix:r
 
 If you get errors related to `--gpus all` flag, you can replace it with `--device /dev/dri/[X]`
 adding this flag for every file in the `/dev/dri/` directory. It makes sure that GPU is
-visibile inside the Docker image. You can also drop it altogether (environment
+visible inside the Docker image. You can also drop it altogether (environment
 will try to perform software rendering).
 
 ## Run environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pygame>=1.9.6
 opencv-python
 psutil
-scipy
+numpy
 gym>=0.11.0
 absl-py
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pygame>=1.9.6
 opencv-python
 psutil
 numpy
-gym>=0.11.0
+gym<=0.21.0
 absl-py
 wheel

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setup(
         'opencv-python',
         'psutil',
         'numpy',
-        'gym>=0.11.0',
+        'gym<=0.21.0',
         'absl-py',
         'wheel',
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ import platform
 import shutil
 from setuptools import find_packages
 from setuptools import setup, Extension
-from setuptools.command.install import install
 from setuptools.command.build_ext import build_ext
 
 
@@ -44,12 +43,6 @@ class CustomBuild(build_ext):
     super(CustomBuild, self).run()
 
   def run_unix(self):
-    # https://stackoverflow.com/questions/32419594/how-to-create-a-dylib-c-extension-on-mac-os-x-with-distutils-and-or-setuptools
-    if sys.platform == 'darwin':
-      from distutils import sysconfig
-      vars = sysconfig.get_config_vars()
-      vars['LDSHARED'] = vars['LDSHARED'].replace('-bundle',
-                                                  '-dynamiclib -Wl,-F.')
     if os.path.exists(self.build_lib):
       dest_dir = os.path.join(self.build_lib, 'gfootball_engine')
     else:
@@ -126,7 +119,7 @@ packages = find_packages() + find_packages('third_party')
 
 setup(
     name='gfootball',
-    version='2.10.2',
+    version='2.10.3',
     description=('Google Research Football - RL environment based on '
                  'open-source game Gameplay Football'),
     long_description=('Please see [our GitHub page](https://github.com/google-research/football) '

--- a/setup.py
+++ b/setup.py
@@ -46,23 +46,23 @@ class CustomBuild(build_ext):
     if os.path.exists(self.build_lib):
       dest_dir = os.path.join(self.build_lib, 'gfootball_engine')
     else:
-      # Development install (pip install -e .)
+      # For the development install (pip install -e .)
+      # gfootball_engine module has to be located in the project root directory.
       dest_dir = "gfootball_engine"
-      if os.system('cp -r third_party/gfootball_engine/ ' + dest_dir):
-        raise OSError("Google Research Football: Could not copy "
-                      "engine to %s." % dest_dir)
-    if os.system('cp -r third_party/fonts ' + dest_dir):
-      raise OSError('Google Research Football: Could not copy '
-                    'fonts to %s.' % dest_dir)
+      if not os.path.exists(dest_dir):
+        try:
+          os.symlink(os.path.abspath('third_party/gfootball_engine'), dest_dir)
+        except:
+          raise OSError("Google Research Football: Could not create symlink to %s"
+                        "for the development install." % dest_dir)
 
     try:
-      use_prebuilt_library = int(
-          os.environ.get('GFOOTBALL_USE_PREBUILT_SO', '0'))
+      use_prebuilt_lib = int(os.environ.get('GFOOTBALL_USE_PREBUILT_SO', '0'))
     except ValueError:
       raise ValueError('Could not parse GFOOTBALL_USE_PREBUILT_SO environment '
                        'variable as int. Please set it to 0 or 1')
 
-    if use_prebuilt_library:
+    if use_prebuilt_lib:
       if os.system(
             'cp third_party/gfootball_engine/lib/prebuilt_gameplayfootball.so ' +
             dest_dir + '/_gameplayfootball.so'):
@@ -70,51 +70,99 @@ class CustomBuild(build_ext):
             'Failed to copy pre-built library to a final destination %s.' %
             dest_dir)
     else:
-      if (os.system('gfootball/build_game_engine.sh') or
-          os.system('cp third_party/gfootball_engine/_gameplayfootball.so ' +
-                    dest_dir)):
+      # Compile the engine
+      if os.system('gfootball/build_game_engine.sh'):
         raise OSError('Google Research Football compilation failed')
+      # There might be multiple compiled modules (e.g. for different python versions)
+      # Copy them all
+      libs = glob.glob(f'third_party/gfootball_engine/_gameplayfootball*.so')
+      copy_compiled_libs(libs, dest_dir)
+    copy_fonts(dest_dir)
 
   def run_windows(self):
-    if os.path.exists(self.build_lib):
-      dest_dir = os.path.join(self.build_lib, 'gfootball_engine')
-    else:  # Development install
-      dest_dir = "gfootball_engine"
-      if not os.path.exists(dest_dir):
-        os.mkdir(dest_dir)
-      # For development mode (pip install -e .) gfootball_engine module has to be located
-      # in the project root directory. So we copy only __init__.py and `data` directory
-      shutil.copy2('third_party/gfootball_engine/__init__.py', dest_dir)
-      data_dir = os.path.join(dest_dir, 'data')
-      if not os.path.exists(data_dir):
-        shutil.copytree('third_party/gfootball_engine/data', data_dir)
-
-    # Copy fonts
-    dst_fonts = os.path.join(dest_dir, "fonts")
-    if not os.path.exists(dst_fonts):
-      shutil.copytree("third_party/fonts", dst_fonts)
-
-    py_major, py_minor, _ = platform.python_version_tuple()
     guide_message = 'Please follow the guide on how to install prerequisites: ' \
-                  'https://github.com/google-research/football/blob/master/gfootball/doc/compile_engine.md#windows'
+                    'https://github.com/google-research/football/blob/master/gfootball/doc/compile_engine.md#windows'
     if not os.environ.get('VCPKG_ROOT'):
       raise OSError('VCPKG_ROOT environment variable is not defined.\n' + guide_message)
+
+    if os.path.exists(self.build_lib):
+      dest_dir = os.path.join(self.build_lib, 'gfootball_engine')
+    else:
+      # For the development install (pip install -e .)
+      # gfootball_engine module has to be located in the project root directory.
+      dest_dir = "gfootball_engine"
+      if not os.path.exists(dest_dir):
+        try:
+          os.symlink(os.path.abspath('third_party/gfootball_engine'), dest_dir, target_is_directory=True)
+        except OSError:
+          # Windows doesn't support symlinks for unprivileged users
+          # Fall back to copying the files
+          os.mkdir(dest_dir)
+          shutil.copy2('third_party/gfootball_engine/__init__.py', dest_dir)
+          data_dir = os.path.join(dest_dir, 'data')
+          if not os.path.exists(data_dir):
+            shutil.copytree('third_party/gfootball_engine/data', data_dir)
+
     os.environ['GENERATOR_PLATFORM'] = 'x64' if sys.maxsize > 2 ** 32 else 'Win32'
+    py_major, py_minor, _ = platform.python_version_tuple()
     os.environ['PY_VERSION'] = f'{py_major}.{py_minor}'
     if os.system('gfootball\\build_game_engine.bat'):
       raise OSError('Google Research Football compilation failed.\n' + guide_message)
     # Copy compiled library and its dependencies
     lib_path = 'third_party/gfootball_engine/build_win/Release/'
     libs = glob.glob(f'{lib_path}*.pyd') + glob.glob(f'{lib_path}*.dll')
-    for file in libs:
-      shutil.copy2(file, dest_dir)
+    copy_compiled_libs(libs, dest_dir)
+    copy_fonts(dest_dir)
 
 
-# To support development (a.k.a. editable) install (`pip install -e .` or `python3 setup.py develop`),
-# we remove `build` directory created by a regular setup
-if 'develop' in sys.argv and os.path.exists('build'):
-  shutil.rmtree('build')
+def copy_compiled_libs(libs, dest_dir):
+  """Copy compiled libraries to the destination directory."""
+  for lib in libs:
+    try:
+      shutil.copy2(lib, dest_dir)
+    except shutil.SameFileError:
+      # In case the file is the same do nothing
+      pass
 
+
+def copy_fonts(dest_dir):
+  """Copy fonts to the destination directory."""
+  dst_fonts = os.path.join(dest_dir, "fonts")
+  if not os.path.exists(dst_fonts):
+    shutil.copytree("third_party/fonts", dst_fonts)
+
+
+def process_develop_setup():
+  """
+  Clean up (if necessary) some directories before or after running
+  setup in development (a.k.a. editable) mode (`pip install -e .`).
+  """
+  if 'develop' in sys.argv and os.path.exists('build'):
+    # Remove `build` directory created by a regular installation
+    shutil.rmtree('build')
+  elif 'develop' not in sys.argv and os.path.exists('gfootball_engine'):
+    # If `pip install .` is called after development mode,
+    # remove the 'fonts' directory copied by a `develop` setup
+    copied_fonts = 'third_party/gfootball_engine/fonts'
+    if os.path.exists(copied_fonts):
+      shutil.rmtree(copied_fonts)
+    # Remove .so files (.pyd on Windows)
+    for empty_lib in glob.glob("brainball_cpp_engine*"):
+      os.remove(empty_lib)
+    # Finally, remove symlink to the gfootball_engine directory
+    if not os.path.exists('gfootball_engine'):
+      return
+    if os.path.islink('gfootball_engine'):
+      if platform.system() == 'Windows':
+        os.remove('gfootball_engine')
+      else:
+        os.unlink('gfootball_engine')
+    else:
+      shutil.rmtree('gfootball_engine')
+
+
+# TODO: Add CI tests for develop setup on all platforms
+process_develop_setup()
 packages = find_packages() + find_packages('third_party')
 
 setup(
@@ -136,7 +184,7 @@ setup(
         'pygame>=1.9.6',
         'opencv-python',
         'psutil',
-        'scipy',
+        'numpy',
         'gym>=0.11.0',
         'absl-py',
         'wheel',

--- a/third_party/gfootball_engine/CMakeLists.txt
+++ b/third_party/gfootball_engine/CMakeLists.txt
@@ -21,18 +21,21 @@ if(WIN32)
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
   set(VCPKG_MANIFEST_DIR "${CMAKE_SOURCE_DIR}/vcpkg_manifests/py$ENV{PY_VERSION}")
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+  # Windows requires the library to have the same name as the module
+  set(OUTPUT_LIB_NAME _gameplayfootball)
 else()  # UNIX
+  set(OUTPUT_LIB_NAME game)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules")
 endif()
 
 project(gameplayfootball)
 set(PACKAGE gameplayfootball)
 
-set (CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14)
 
 if(UNIX)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -fPIC -g -O3")
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O3 -g")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -fPIC -g -O3")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O3 -g")
   set(OpenGL_GL_PREFERENCE GLVND)
 endif(UNIX)
 
@@ -63,11 +66,11 @@ include_directories(${SDL2_TTF_DIRS})
 include_directories(${SDL2_GFX_DIRS})
 
 if(UNIX)
-  if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
     find_package(Python COMPONENTS Development REQUIRED)
   else()
     # Starting from CMake 3.12 FindPythonLibs was deprecated in favour of FindPython.
-    # But Ubuntu 18.04 and other older distributions have CMake version less than 3.12,
+    # But Ubuntu 18.04 and other older distributions are shipped with CMake version < 3.12,
     # so we have to support the old behaviour for some time.
     find_package(PythonLibs 3 REQUIRED)
     string(REPLACE "." ";" VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
@@ -91,6 +94,11 @@ endif()
 
 message("Using Python: ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
 include_directories(${Python_INCLUDE_DIRS})
+if(NOT WIN32 AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.15")
+  set(Py_TARGETS Python::Module)
+else()
+  set(Py_TARGETS ${Python_LIBRARIES})
+endif()
 
 # Include Boost Python.
 if(WIN32 OR APPLE)
@@ -159,18 +167,11 @@ endif()
 
 set(LIBRARIES gamelib menulib datalib blunted2
    Boost::filesystem Boost::system Boost::thread Boost::${BOOST_PYTHON_VERSION}
-   ${Python_LIBRARIES} ${SDL2_LIBS_ALL} ${EGL_LIBRARIES} ${OPENGL_LIBRARIES})
+   ${Py_TARGETS} ${SDL2_LIBS_ALL} ${EGL_LIBRARIES} ${OPENGL_LIBRARIES})
 
-if(UNIX)
-  set(LIB_NAME game)
-else()  # WIN32
-  # Windows requires the library to have the same name as the module
-  set(LIB_NAME _gameplayfootball)
-endif()
-
-add_library(${LIB_NAME} SHARED ${CORE_SOURCES} ${CORE_HEADERS} ${AI_HEADERS} ${AI_SOURCES})
-target_link_libraries(${LIB_NAME} ${LIBRARIES})
+add_library(${OUTPUT_LIB_NAME} SHARED ${CORE_SOURCES} ${CORE_HEADERS} ${AI_HEADERS} ${AI_SOURCES})
+target_link_libraries(${OUTPUT_LIB_NAME} ${LIBRARIES})
 
 if(WIN32)
-  set_target_properties(${LIB_NAME} PROPERTIES SUFFIX ".pyd")
+  set_target_properties(${OUTPUT_LIB_NAME} PROPERTIES SUFFIX ".pyd")
 endif()

--- a/third_party/gfootball_engine/src/defines.hpp
+++ b/third_party/gfootball_engine/src/defines.hpp
@@ -43,7 +43,7 @@
 #include <boost/thread/condition.hpp>
 #include <boost/signals2.hpp>
 #include <boost/signals2/slot.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include "backtrace.h"
 #include "base/log.hpp"
 
@@ -58,6 +58,8 @@ constexpr float EPSILON = 0.000001;
 #define MAX_PLAYERS 11
 
 typedef std::string screenshoot;
+
+using namespace boost::placeholders;
 
 namespace blunted {
   class Animation;

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.10/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.10/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.2",
+  "version-string": "2.10.3",
   "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.6/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.6/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.2",
+  "version-string": "2.10.3",
   "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.7/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.7/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.2",
+  "version-string": "2.10.3",
   "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.8/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.8/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.2",
+  "version-string": "2.10.3",
   "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",

--- a/third_party/gfootball_engine/vcpkg_manifests/py3.9/vcpkg.json
+++ b/third_party/gfootball_engine/vcpkg_manifests/py3.9/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gfootball-engine",
-  "version-string": "2.10.2",
+  "version-string": "2.10.3",
   "builtin-baseline": "b18b17865cfb6bd24620a00f30691be6775abb96",
   "dependencies": [
     "python3",


### PR DESCRIPTION
This PR implements multiple changes:
- Add Conda support on macOS (fixes #156, fixes #192, fixes #312).
- Improve development setup on all platforms: use symlink instead of copying, clean files when reinstalled with a regular setup.
- Fix Boost.Bind compilation warnings.
- Replace scipy dependency with numpy.
- Limit Gym version to v0.21.0 for now.
- Add GitHub workflow for building on macOS on every push to the repository.

I had to limit Gym version to 0.21.0 because there are some [breaking changes](https://github.com/openai/gym/releases) and the tests in `gym_test.py` don't pass. It shouldn't require many changes to support the latest version, but it's a topic for another PR.

I implemented most of these changes more than a month ago, but then I [started working](https://github.com/vi3itor/football/tree/pybind) on migrating `gfootball` from `boost-python` to `pybind11`. I'll list all the benefits of transitioning in a separate draft PR, but the main advantage will be the ability to automate wheel building for Linux and macOS. Unfortunately, prior commitments and the war-related news have taken my free time recently, but I'll try to finish it in the upcoming weeks. It's mostly ready but requires fixing several tests and optimizing, e.g., to avoid unnecessary copying of the containers.

As usual, I [tested](https://github.com/vi3itor/test-pypi-gfootball/actions/runs/1979280799) this PR in a separate repository. Today is the last day when we can use `windows-2016` VM to build Windows wheels for Python 3.6-3.10; from tomorrow, March 15, it will become unavailable. If you don't have time to merge this PR today, I'll push another commit to switch to `windows-latest` tomorrow, but for now, it will support only Python 3.9 and 3.10. When we migrate to `pybind11`, it will be possible to build `gfootball` with any supported Python (>=3.7) on any platform.

By the way, some opened issues should also be closed by this or earlier PRs: fixes #168, fixes #274, fixes #303, fixes #304, fixes #306.
Some other opened issues are either stale or should be reopened by the authors with providing additional information: closes #193, closes #276, closes #282, closes #283, closes #290, closes #291, closes #300, closes #302, closes #310. 